### PR TITLE
Added "virtualgl" to solve render driver issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ LABEL maintainer="Pierre Gordon <pierregordon@protonmail.com>"
 RUN echo http://dl-cdn.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories && \
     apk add --no-cache \
         ffmpeg \
-        android-tools && \
+        android-tools \
+        virtualgl && \
     apk add --no-cache --virtual .build-deps \
         curl \
         ffmpeg-dev \


### PR DESCRIPTION
Fix for the "CRITICAL: Could not create renderer: Couldn't find matching render driver" error report in https://github.com/pierlon/scrcpy-docker/issues/4 and https://github.com/pierlon/scrcpy-docker/issues/6

I moved the "virtualgl" installation to the root Dockerfile as requested in the previous pull request https://github.com/pierlon/scrcpy-docker/pull/7