### PR TITLE
Use docker-compose to easily run and build the images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ RUN apk add --no-cache \
         virtualgl
 
 COPY --from=builder /scrcpy-server.jar /usr/local/share/scrcpy/
+COPY --from=builder /scrcpy-server.jar /usr/local/bin/
 COPY --from=builder /scrcpy/x/app/scrcpy /usr/local/bin/
 
 ### runner (amd)

--- a/README.md
+++ b/README.md
@@ -28,11 +28,7 @@ For example: `pierlo1/scrcpy:amd`.
 Now let's run the image:
 
 ```shell
-$ docker run --rm -i -t --privileged \
-    -v /dev/bus/usb:/dev/bus/usb \
-    -v /tmp/.X11-unix:/tmp/.X11-unix \
-    -e DISPLAY=$DISPLAY \
-    pierlo1/scrcpy:<graphics type>
+$ docker-compose run scrcpy-<graphics type> bash
 ```
 
 Inside the container, verify you can see your Android device with:
@@ -48,3 +44,20 @@ And finally, run `scrcpy`:
 $ scrcpy [options]
 ```
 
+If everything is set up once Android keys should be cached in the scrcpy Docker volume and you will be able to run the following command to immediately start the scrcpy session
+```shell
+docker-compose run scrcpy-<graphics type>
+```
+
+
+## Building
+
+```shell
+docker-compose build scrcpy
+```
+
+
+## Pushing
+```shell
+docker-compose build scrcpy
+```

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ $ scrcpy [options]
 
 If everything is set up once Android keys should be cached in the scrcpy Docker volume and you will be able to run the following command to immediately start the scrcpy session
 ```shell
-docker-compose run scrcpy-<graphics type>
+xhost local:root; docker-compose run scrcpy-<graphics type>
 ```
 
 
@@ -59,5 +59,5 @@ docker-compose build scrcpy
 
 ## Pushing
 ```shell
-docker-compose build scrcpy
+docker-compose push scrcpy
 ```

--- a/README.md
+++ b/README.md
@@ -46,8 +46,10 @@ $ scrcpy [options]
 
 If everything is set up once Android keys should be cached in the scrcpy Docker volume and you will be able to run the following command to immediately start the scrcpy session
 ```shell
-xhost local:root; docker-compose run scrcpy-<graphics type>
+xhost local:root; docker-compose run scrcpy-<graphics type> [options]
 ```
+Example:
+`xhost local:root; docker-compose run scrcpy-intel scrcpy -S`
 
 
 ## Building

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,56 @@
+version: '3.4'
+services:
+  scrcpy-intel:
+    build:
+      context: .
+      target: intel
+    image: pierlo1/scrcpy:intel
+    privileged: true
+    environment:
+      - DISPLAY=$DISPLAY
+    volumes:
+      - /tmp/.X11-unix:/tmp/.X11-unix
+      - /dev/bus/usb:/dev/bus/usb
+      - /etc/machine-id:/etc/machine-id
+      - scrcpy:/root/.android
+    devices:
+      - /dev/snd
+    command: scrcpy -S
+
+  scrcpy-amd:
+    build:
+      context: .
+      target: intel
+    image: pierlo1/scrcpy:amd
+    privileged: true
+    environment:
+      - DISPLAY=$DISPLAY
+    volumes:
+      - /tmp/.X11-unix:/tmp/.X11-unix
+      - /dev/bus/usb:/dev/bus/usb
+      - /etc/machine-id:/etc/machine-id
+      - scrcpy:/root/.android
+    devices:
+      - /dev/snd
+    command: scrcpy -S
+  
+  scrcpy-nvidia:
+    build:
+      context: .
+      target: intel
+    image: pierlo1/scrcpy:nvidia
+    privileged: true
+    environment:
+      - DISPLAY=$DISPLAY
+    volumes:
+      - /tmp/.X11-unix:/tmp/.X11-unix
+      - /dev/bus/usb:/dev/bus/usb
+      - /etc/machine-id:/etc/machine-id
+      - scrcpy:/root/.android
+    devices:
+      - /dev/snd
+    command: scrcpy -S
+
+
+volumes:
+  scrcpy:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     privileged: true
     environment:
       - DISPLAY=$DISPLAY
+      - ADB_VENDOR_KEYS:/root/.android
     volumes:
       - /tmp/.X11-unix:/tmp/.X11-unix
       - /dev/bus/usb:/dev/bus/usb
@@ -25,6 +26,7 @@ services:
     privileged: true
     environment:
       - DISPLAY=$DISPLAY
+      - ADB_VENDOR_KEYS:/root/.android
     volumes:
       - /tmp/.X11-unix:/tmp/.X11-unix
       - /dev/bus/usb:/dev/bus/usb
@@ -42,6 +44,7 @@ services:
     privileged: true
     environment:
       - DISPLAY=$DISPLAY
+      - ADB_VENDOR_KEYS:/root/.android
     volumes:
       - /tmp/.X11-unix:/tmp/.X11-unix
       - /dev/bus/usb:/dev/bus/usb

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,7 @@ services:
       - scrcpy:/root/.android
     devices:
       - /dev/snd
-    command: scrcpy -S
+    command: scrcpy
 
 
 volumes:

--- a/hooks/build
+++ b/hooks/build
@@ -1,9 +1,0 @@
-#!/bin/bash
-set -ex
-
-for target in amd intel nvidia; do
-    docker build \
-        --tag "$DOCKER_REPO:$target" \
-        --target "$target" \
-        .
-done

--- a/hooks/push
+++ b/hooks/push
@@ -1,6 +1,0 @@
-#!/bin/bash
-set -ex
-
-for target in amd intel nvidia; do
-    docker push "$DOCKER_REPO:$target"
-done


### PR DESCRIPTION
Use docker-compose to easily run and build the images

Also fixed a bug in the Dockerfile where the scrcpy-server.jar file was at the wrong place (`adb: error: cannot stat '/usr/local/bin/scrcpy-server.jar': No such file or directory`)